### PR TITLE
refactor: uses api-test-utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ To configure the environment variables, run:
    
 3. From the root directory of the `performance-test-locust` project execute `docker-compose up` command.
 
-4. Run `Main.main()` method in the `performance-test-locust` project. 
+4. Run `Main.main()` method in `performance-test-locust` project. 
     - You can run it directly via your IDE -> open `Main` class and click on a green arrow next to the `main()` method 
     - or by using the following command: `mvn clean compile exec:java`
     

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <dependency>
       <groupId>com.github.myzhan</groupId>
       <artifactId>locust4j</artifactId>
-      <version>1.0.5</version>
+      <version>1.0.8</version>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.hisp.dhis</groupId>
       <artifactId>api-test-utils</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.2</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/hisp/dhis/Main.java
+++ b/src/main/java/org/hisp/dhis/Main.java
@@ -28,18 +28,6 @@ public class Main
     public static void main( String[] args )
         throws IOException
     {
-
-        // Configure RestAssured mapper to convert any date into DHIS2 format
-
-      /* RestAssured.config = new RestAssuredConfig(  )
-            .objectMapperConfig( new ObjectMapperConfig().jackson2ObjectMapperFactory( ( type, s ) -> {
-                ObjectMapper om = new ObjectMapper().findAndRegisterModules();
-
-                DateFormat df = new SimpleDateFormat( "yyyy-MM-dd" );
-                om.setDateFormat( df );
-                return om;
-            } ) );
-*/
         RestAssured.config = config().
             decoderConfig(
                 new DecoderConfig( "UTF-8" )

--- a/src/main/java/org/hisp/dhis/Main.java
+++ b/src/main/java/org/hisp/dhis/Main.java
@@ -1,28 +1,22 @@
 package org.hisp.dhis;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.myzhan.locust4j.Locust;
+import com.google.gson.GsonBuilder;
 import io.restassured.RestAssured;
+import io.restassured.config.DecoderConfig;
+import io.restassured.config.EncoderConfig;
 import io.restassured.config.ObjectMapperConfig;
+import io.restassured.mapper.ObjectMapperType;
 import org.hisp.dhis.cache.EntitiesCache;
 import org.hisp.dhis.locust.LocustConfig;
 import org.hisp.dhis.locust.LocustSlave;
-import org.hisp.dhis.tasks.AddTeiTask;
-import org.hisp.dhis.tasks.GetHeavyAnalyticsRandomTask;
-import org.hisp.dhis.tasks.GetHeavyAnalyticsTask;
-import org.hisp.dhis.tasks.LoginTask;
-import org.hisp.dhis.tasks.ReserveTrackedEntityAttributeValuesTask;
+import org.hisp.dhis.tasks.*;
 
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
 
 import static io.restassured.config.RestAssuredConfig.config;
 import static org.aeonbits.owner.ConfigFactory.create;
-import static org.hisp.dhis.utils.CacheUtils.cacheExists;
-import static org.hisp.dhis.utils.CacheUtils.deserializeCache;
-import static org.hisp.dhis.utils.CacheUtils.getCachePath;
-import static org.hisp.dhis.utils.CacheUtils.serializeCache;
+import static org.hisp.dhis.utils.CacheUtils.*;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -35,16 +29,30 @@ public class Main
         throws IOException
     {
 
-        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
         // Configure RestAssured mapper to convert any date into DHIS2 format
 
-        RestAssured.config = config()
+      /* RestAssured.config = new RestAssuredConfig(  )
             .objectMapperConfig( new ObjectMapperConfig().jackson2ObjectMapperFactory( ( type, s ) -> {
                 ObjectMapper om = new ObjectMapper().findAndRegisterModules();
+
                 DateFormat df = new SimpleDateFormat( "yyyy-MM-dd" );
                 om.setDateFormat( df );
                 return om;
             } ) );
+*/
+        RestAssured.config = config().
+            decoderConfig(
+                new DecoderConfig( "UTF-8" )
+            ).encoderConfig(
+            new EncoderConfig( "UTF-8", "UTF-8" )
+        ).objectMapperConfig(
+            new ObjectMapperConfig()
+                .defaultObjectMapperType( ObjectMapperType.GSON )
+                .gsonObjectMapperFactory( ( type, s ) -> new GsonBuilder().setDateFormat( "yyyy-MM-dd" ).create() )
+
+        );
+
+        RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
 
         RestAssured.baseURI = cfg.targetUri();
         EntitiesCache cache;
@@ -69,10 +77,16 @@ public class Main
         Locust locust = locustSlave.init();
 
         locust.run(
-                new AddTeiTask( 50, cache ),
-                new GetHeavyAnalyticsTask( 30, cfg.analyticsApiVersion() ),
-                new GetHeavyAnalyticsRandomTask( 30, cfg.analyticsApiVersion(), cache ),
-                new ReserveTrackedEntityAttributeValuesTask( 30 )
+            new QueryFilterTeiTask( 3 ),
+            new GetHeavyAnalyticsRandomTask( 1, cfg.analyticsApiVersion(), cache ),
+            new GetHeavyAnalyticsTask( 1, cfg.analyticsApiVersion() ),
+            new AddTeiTask( 5, cache ),
+            new FilterTeiTask( 5 ),
+            new CreateTrackedEntityAttributeTask( 5 ),
+            new MetadataExportImportTask( 1 ),
+            new ReserveTrackedEntityAttributeValuesTask( 1 )
+            //new QueryFilterTeiTask( 4 )
+            //new AddTeiTask( 1, cache )
         );
     }
 }

--- a/src/main/java/org/hisp/dhis/cache/DataElement.java
+++ b/src/main/java/org/hisp/dhis/cache/DataElement.java
@@ -16,6 +16,7 @@ public class DataElement
 
     private List<String> optionSet;
 
-    public DataElement() {
+    public DataElement()
+    {
     }
 }

--- a/src/main/java/org/hisp/dhis/cache/GeneratedTrackedEntityAttribute.java
+++ b/src/main/java/org/hisp/dhis/cache/GeneratedTrackedEntityAttribute.java
@@ -3,11 +3,7 @@ package org.hisp.dhis.cache;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hisp.dhis.common.ValueType;
-
-import java.util.List;
 
 @Data
 @AllArgsConstructor
@@ -16,12 +12,17 @@ import java.util.List;
 public class GeneratedTrackedEntityAttribute
 {
     private String aggregationType = "NONE";
-    private boolean generated = true;
-    private String name = "test generated value";
-    private String pattern = "RANDOM(####)";
-    private String shortName = "test_generated_value3";
-    private boolean unique = true;
-    private String valueType = "TEXT";
 
+    private boolean generated = true;
+
+    private String name = "test generated value";
+
+    private String pattern = "RANDOM(####)";
+
+    private String shortName = "test_generated_value3";
+
+    private boolean unique = true;
+
+    private String valueType = "TEXT";
 
 }

--- a/src/main/java/org/hisp/dhis/cache/Program.java
+++ b/src/main/java/org/hisp/dhis/cache/Program.java
@@ -1,9 +1,9 @@
 package org.hisp.dhis.cache;
 
-import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -17,13 +17,14 @@ public class Program
 
     private List<ProgramAttribute> attributes;
 
+    private String entityType;
+
+    public Program()
+    {
+    }
+
     public String getOrgUnit( int index )
     {
         return this.orgUnits.get( index );
-    }
-
-    private String entityType;
-
-    public Program() {
     }
 }

--- a/src/main/java/org/hisp/dhis/cache/ProgramAttribute.java
+++ b/src/main/java/org/hisp/dhis/cache/ProgramAttribute.java
@@ -53,6 +53,8 @@ public class ProgramAttribute
 
     private List<String> options;
 
-    public ProgramAttribute() {}
+    public ProgramAttribute()
+    {
+    }
 
 }

--- a/src/main/java/org/hisp/dhis/cache/ProgramStage.java
+++ b/src/main/java/org/hisp/dhis/cache/ProgramStage.java
@@ -13,6 +13,7 @@ public class ProgramStage
 
     private List<DataElement> dataElements;
 
-    public ProgramStage() {
+    public ProgramStage()
+    {
     }
 }

--- a/src/main/java/org/hisp/dhis/cache/TeiType.java
+++ b/src/main/java/org/hisp/dhis/cache/TeiType.java
@@ -13,5 +13,7 @@ public class TeiType
 
     private String name;
 
-    public TeiType() {}
+    public TeiType()
+    {
+    }
 }

--- a/src/main/java/org/hisp/dhis/random/TrackedEntityInstanceRandomizer.java
+++ b/src/main/java/org/hisp/dhis/random/TrackedEntityInstanceRandomizer.java
@@ -1,18 +1,9 @@
 package org.hisp.dhis.random;
 
-import static net.andreinc.mockneat.unit.time.LocalDates.localDates;
-import static net.andreinc.mockneat.unit.types.Bools.bools;
-import static net.andreinc.mockneat.unit.types.Doubles.doubles;
-import static net.andreinc.mockneat.unit.types.Ints.ints;
-import static org.hisp.dhis.utils.DataRandomizer.randomSequence;
-
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.time.format.DateTimeFormatter;
-import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
+import net.andreinc.mockneat.types.enums.StringType;
+import net.andreinc.mockneat.unit.objects.From;
+import net.andreinc.mockneat.unit.text.Strings;
+import net.andreinc.mockneat.unit.types.Ints;
 import org.hisp.dhis.cache.DataElement;
 import org.hisp.dhis.cache.EntitiesCache;
 import org.hisp.dhis.cache.Program;
@@ -31,10 +22,17 @@ import org.hisp.dhis.textpattern.*;
 import org.hisp.dhis.utils.DataRandomizer;
 import org.springframework.util.StringUtils;
 
-import net.andreinc.mockneat.types.enums.StringType;
-import net.andreinc.mockneat.unit.objects.From;
-import net.andreinc.mockneat.unit.text.Strings;
-import net.andreinc.mockneat.unit.types.Ints;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static net.andreinc.mockneat.unit.time.LocalDates.localDates;
+import static net.andreinc.mockneat.unit.types.Bools.bools;
+import static net.andreinc.mockneat.unit.types.Doubles.doubles;
+import static net.andreinc.mockneat.unit.types.Ints.ints;
 
 public class TrackedEntityInstanceRandomizer
 {
@@ -71,12 +69,12 @@ public class TrackedEntityInstanceRandomizer
         enrollment.setEvents( IntStream.rangeClosed( 1, eventsSize ).mapToObj( i -> {
 
             Event event = new Event();
-            event.setDueDate( df.format(new Date()) );
+            event.setDueDate( df.format( new Date() ) );
             event.setProgram( program.getUid() );
             event.setProgramStage( programStage.getUid() );
             event.setOrgUnit( ou );
             event.setStatus( EventStatus.ACTIVE );
-            event.setEventDate( df.format(new Date()) );
+            event.setEventDate( df.format( new Date() ) );
             event.setFollowup( false );
             event.setDeleted( false );
             event.setAttributeOptionCombo( "" ); // TODO
@@ -103,10 +101,10 @@ public class TrackedEntityInstanceRandomizer
         Set<DataValue> dataValues = new HashSet<>();
         int numberOfDataValuesToCreate = Ints.ints().range( min, max ).get();
         List<Integer> indexes = DataRandomizer.randomSequence( programStage.getDataElements().size(), numberOfDataValuesToCreate );
-        
+
         for ( Integer index : indexes )
         {
-            dataValues.add( withRandomValue( programStage.getDataElements().get(index)));
+            dataValues.add( withRandomValue( programStage.getDataElements().get( index ) ) );
         }
 
         return dataValues;
@@ -122,7 +120,8 @@ public class TrackedEntityInstanceRandomizer
         {
             val = From.from( dataElement.getOptionSet() ).get();
         }
-        else {
+        else
+        {
 
             val = rndValueFrom( dataElement.getValueType() );
         }
@@ -130,7 +129,7 @@ public class TrackedEntityInstanceRandomizer
         return dataValue;
     }
 
-    private Program getRandomProgram(EntitiesCache cache)
+    private Program getRandomProgram( EntitiesCache cache )
     {
         return From.from( cache.getPrograms() ).get();
     }
@@ -229,7 +228,6 @@ public class TrackedEntityInstanceRandomizer
         }
         return val;
     }
-
 
     private String withPattern( TextPattern textPattern )
     {

--- a/src/main/java/org/hisp/dhis/tasks/CreateTrackedEntityAttributeTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/CreateTrackedEntityAttributeTask.java
@@ -1,12 +1,10 @@
 package org.hisp.dhis.tasks;
 
-import io.restassured.http.ContentType;
-import io.restassured.response.Response;
+import org.hisp.dhis.actions.RestApiActions;
 import org.hisp.dhis.cache.GeneratedTrackedEntityAttribute;
+import org.hisp.dhis.response.dto.ApiResponse;
 
 import java.util.UUID;
-
-import static io.restassured.RestAssured.given;
 
 public class CreateTrackedEntityAttributeTask
     extends
@@ -14,38 +12,45 @@ public class CreateTrackedEntityAttributeTask
 {
     private String id;
 
-    public int getWeight()
+    private String endpoint = "/api/trackedEntityAttributes";
+
+    public CreateTrackedEntityAttributeTask( int weight )
     {
-        return 1;
+        this.weight = weight;
+    }
+
+    public CreateTrackedEntityAttributeTask()
+    {
+        this.weight = 1;
     }
 
     public String getName()
     {
-        return "POST /api/trackedEntityAttribute";
+        return "POST " + endpoint;
     }
 
     public void execute()
     {
         long time = System.currentTimeMillis();
 
-        Response response = null;
-
         GeneratedTrackedEntityAttribute generatedAttribute = new GeneratedTrackedEntityAttribute();
         generatedAttribute.setName( generatedAttribute.getName() + UUID.randomUUID() );
-        generatedAttribute.setShortName( ""+UUID.randomUUID() );
-        response = given().contentType( ContentType.JSON ).body( generatedAttribute ).when()
-            .post( "/api/trackedEntityAttributes" ).thenReturn();
-        if ( response.getStatusCode() == 201 ) {
-            id = response.jsonPath().get( "response.uid");
+        generatedAttribute.setShortName( "" + UUID.randomUUID() );
+
+        ApiResponse response = new RestApiActions( this.endpoint ).post( generatedAttribute );
+
+        if ( response.statusCode() == 201 )
+        {
+            id = response.extractString( "response.uid" );
         }
 
         if ( response.statusCode() == 201 )
         {
-            recordSuccess( response );
+            recordSuccess( response.getRaw() );
         }
         else
         {
-            recordFailure( response );
+            recordFailure( response.getRaw() );
         }
     }
 

--- a/src/main/java/org/hisp/dhis/tasks/DhisAbstractTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/DhisAbstractTask.java
@@ -12,7 +12,8 @@ public abstract class DhisAbstractTask
 {
     protected int weight;
 
-    public int getWeight() {
+    public int getWeight()
+    {
         return this.weight;
     }
 

--- a/src/main/java/org/hisp/dhis/tasks/FilterTeiTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/FilterTeiTask.java
@@ -28,21 +28,22 @@ package org.hisp.dhis.tasks;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static io.restassured.RestAssured.when;
-
-import io.restassured.response.Response;
+import org.hisp.dhis.actions.RestApiActions;
+import org.hisp.dhis.response.dto.ApiResponse;
 
 /**
  * @author David Katuscak (katuscak.d@gmail.com)
  */
-public class FilterTeiTask extends DhisAbstractTask
+public class FilterTeiTask
+    extends DhisAbstractTask
 {
-    private String endpoint = "/api/trackedEntityInstances.json";
+    private String endpoint = "/api/trackedEntityInstances";
+
     private String query = "?ou=DiszpKrYNg8&filter=TfdH5KvFmMy:GE:Karoline&fields=*&includeAllAttributes=true";
 
-    public int getWeight()
+    public FilterTeiTask( int weight )
     {
-        return 1;
+        this.weight = weight;
     }
 
     @Override
@@ -52,16 +53,16 @@ public class FilterTeiTask extends DhisAbstractTask
     }
 
     @Override
-    public void execute() throws Exception
+    public void execute()
     {
-        Response response = when().get( endpoint + query );
+        ApiResponse response = new RestApiActions( endpoint ).get( query );
 
         if ( response.statusCode() == 200 )
         {
-            recordSuccess( response );
+            recordSuccess( response.getRaw() );
             return;
         }
 
-        recordFailure( response );
+        recordFailure( response.getRaw() );
     }
 }

--- a/src/main/java/org/hisp/dhis/tasks/GetAndUpdateEventsTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/GetAndUpdateEventsTask.java
@@ -1,7 +1,6 @@
 package org.hisp.dhis.tasks;
 
 import com.google.gson.JsonObject;
-import sun.rmi.runtime.Log;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -11,7 +10,8 @@ public class GetAndUpdateEventsTask
 {
     private String query;
 
-    public GetAndUpdateEventsTask(String eventsQuery) {
+    public GetAndUpdateEventsTask( String eventsQuery )
+    {
         this.query = eventsQuery;
     }
 

--- a/src/main/java/org/hisp/dhis/tasks/GetHeavyAnalyticsRandomTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/GetHeavyAnalyticsRandomTask.java
@@ -1,20 +1,17 @@
 package org.hisp.dhis.tasks;
 
-import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_OK;
-import static io.restassured.RestAssured.given;
-import static java.lang.String.format;
-import static java.lang.String.join;
-import static java.lang.String.valueOf;
-import static java.util.Arrays.asList;
-import static net.andreinc.mockneat.unit.objects.From.from;
+import org.hisp.dhis.actions.RestApiActions;
+import org.hisp.dhis.cache.EntitiesCache;
+import org.hisp.dhis.cache.Program;
+import org.hisp.dhis.request.QueryParamsBuilder;
+import org.hisp.dhis.response.dto.ApiResponse;
 
 import java.util.List;
 
-import org.hisp.dhis.cache.EntitiesCache;
-import org.hisp.dhis.cache.Program;
-
-import io.restassured.response.Response;
-import io.restassured.specification.RequestSpecification;
+import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_OK;
+import static java.lang.String.*;
+import static java.util.Arrays.asList;
+import static net.andreinc.mockneat.unit.objects.From.from;
 
 /**
  * @author Maikel Arabori <maikelarabori@gmail.com>
@@ -32,9 +29,9 @@ public class GetHeavyAnalyticsRandomTask
 
     private static final String DISPLAY_PROPERTY = "NAME";
 
-    private static final boolean SKIP_META = true;
+    private static final String SKIP_META = "true";
 
-    private static final boolean INCLUDE_NUM_DEN = true;
+    private static final String INCLUDE_NUM_DEN = "true";
 
     private static final String DIMENSIONS = "dx:" + join( ";",
         asList( "AUqdhY4mpvp", "EY8gsfEomc0", "EoYar8UxddG", "GQHKiAe3DHR", "GfYjGL16D0W", "JIVMtpjVZqJ", "Lzg9LtG1xg3",
@@ -45,9 +42,10 @@ public class GetHeavyAnalyticsRandomTask
             "sB79w2hiLp8", "sMTMkudvLCD", "tcs5YGnjiKo", "ulgL07PF8rq", "vKWOc4itBo2", "vihpFUg2WTy" ) );
 
     private final EntitiesCache entitiesCache;
+
     private final int apiVersion;
 
-    public GetHeavyAnalyticsRandomTask(final int weight, final int apiVersion, final EntitiesCache entitiesCache )
+    public GetHeavyAnalyticsRandomTask( final int weight, final int apiVersion, final EntitiesCache entitiesCache )
     {
         this.weight = weight;
         this.apiVersion = apiVersion;
@@ -64,22 +62,25 @@ public class GetHeavyAnalyticsRandomTask
         // Given
         final Program aRandomProgram = randomProgram();
         final String aRandomOrgUnitUid = randomOrgUnitUid( aRandomProgram.getOrgUnits() );
-        final RequestSpecification request = given().queryParam( "filter", format( ORG_UNIT, aRandomOrgUnitUid ) )
-            .queryParam( "dimension", DIMENSIONS ).queryParam( "dimension", PERIOD )
-            .queryParam( "displayProperty", DISPLAY_PROPERTY ).queryParam( "skipMeta", SKIP_META )
-            .queryParam( "includeNumDen", INCLUDE_NUM_DEN );
 
-        // Test
-        final Response response = request.get( endpoint() );
+        ApiResponse response = new RestApiActions( "api/analytics" )
+            .get( "", new QueryParamsBuilder()
+                .add( "filter", format( ORG_UNIT, aRandomOrgUnitUid ) )
+                .add( "dimension", DIMENSIONS )
+                .add( "dimension", PERIOD )
+                .add( "displayProperty", DISPLAY_PROPERTY )
+                .add( "skipMeta", SKIP_META )
+                .add( "includeNumDen", INCLUDE_NUM_DEN )
+            );
 
         // Assert and record
         if ( response.statusCode() == STATUS_CODE_OK )
         {
-            recordSuccess( response );
+            recordSuccess( response.getRaw() );
         }
         else
         {
-            recordFailure( response );
+            recordFailure( response.getRaw() );
         }
     }
 

--- a/src/main/java/org/hisp/dhis/tasks/GetHeavyAnalyticsTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/GetHeavyAnalyticsTask.java
@@ -1,15 +1,15 @@
 package org.hisp.dhis.tasks;
 
-import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_OK;
-import static io.restassured.RestAssured.given;
-import static java.lang.String.join;
-import static java.lang.String.valueOf;
-import static java.util.Arrays.asList;
+import org.hisp.dhis.actions.RestApiActions;
+import org.hisp.dhis.request.QueryParamsBuilder;
+import org.hisp.dhis.response.dto.ApiResponse;
 
 import java.util.List;
 
-import io.restassured.response.Response;
-import io.restassured.specification.RequestSpecification;
+import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_OK;
+import static java.lang.String.join;
+import static java.lang.String.valueOf;
+import static java.util.Arrays.asList;
 
 /**
  * @author Maikel Arabori <maikelarabori@gmail.com>
@@ -27,9 +27,9 @@ public class GetHeavyAnalyticsTask
 
     private static final String DISPLAY_PROPERTY = "NAME";
 
-    private static final boolean SKIP_META = true;
+    private static final String SKIP_META = "true";
 
-    private static final boolean INCLUDE_NUM_DEN = true;
+    private static final String INCLUDE_NUM_DEN = "true";
 
     private static final String DIMENSIONS = "dx:" + join( ";",
         asList( "AUqdhY4mpvp", "EY8gsfEomc0", "EoYar8UxddG", "GQHKiAe3DHR", "GfYjGL16D0W", "JIVMtpjVZqJ", "Lzg9LtG1xg3",
@@ -41,7 +41,7 @@ public class GetHeavyAnalyticsTask
 
     private final int apiVersion;
 
-    public GetHeavyAnalyticsTask(final int weight, final int apiVersion )
+    public GetHeavyAnalyticsTask( final int weight, final int apiVersion )
     {
         this.weight = weight;
         this.apiVersion = apiVersion;
@@ -54,23 +54,29 @@ public class GetHeavyAnalyticsTask
 
     public void execute()
     {
+
         // Given
-        final RequestSpecification request = given().queryParam( "filter", ORG_UNIT )
-            .queryParam( "dimension", DIMENSIONS ).queryParam( "dimension", PERIOD )
-            .queryParam( "displayProperty", DISPLAY_PROPERTY ).queryParam( "skipMeta", SKIP_META )
-            .queryParam( "includeNumDen", INCLUDE_NUM_DEN );
+        RestApiActions restApiActions = new RestApiActions( endpoint() );
+
+        QueryParamsBuilder queryParamsBuilder = new QueryParamsBuilder()
+            .add( "filter", ORG_UNIT )
+            .add( "dimension", PERIOD )
+            .add( "displayProperty", DISPLAY_PROPERTY )
+            .add( "skipMeta", SKIP_META )
+            .add( "includeNumDen", INCLUDE_NUM_DEN );
 
         // Test
-        final Response response = request.get( endpoint() );
 
+        ApiResponse response = restApiActions.get( queryParamsBuilder.build() );
         // Assert and record
+
         if ( response.statusCode() == STATUS_CODE_OK )
         {
-            recordSuccess( response );
+            recordSuccess( response.getRaw() );
         }
         else
         {
-            recordFailure( response );
+            recordFailure( response.getRaw() );
         }
     }
 

--- a/src/main/java/org/hisp/dhis/tasks/MetadataExportTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/MetadataExportTask.java
@@ -1,8 +1,8 @@
 package org.hisp.dhis.tasks;
 
 import com.google.gson.JsonObject;
-import io.restassured.response.Response;
-import org.hisp.dhis.RestAssured;
+import org.hisp.dhis.actions.RestApiActions;
+import org.hisp.dhis.response.dto.ApiResponse;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -11,6 +11,8 @@ public class MetadataExportTask
     extends DhisAbstractTask
 {
     private JsonObject responseBody;
+
+    private String endpoint = "/api/metadata";
 
     public int getWeight()
     {
@@ -25,20 +27,19 @@ public class MetadataExportTask
     public void execute()
         throws Exception
     {
-        Response response = RestAssured.getRestAssured()
-            .given()
-            .get( "api/metadata" )
-            .thenReturn();
+        RestApiActions apiActions = new RestApiActions( endpoint );
 
-        this.responseBody = response.body().as( JsonObject.class );
+        ApiResponse response = apiActions.get();
+
+        this.responseBody = response.getBody();
 
         if ( response.statusCode() != 200 )
         {
-            recordFailure( response );
+            recordFailure( response.getRaw() );
             return;
         }
 
-        recordSuccess( response );
+        recordSuccess( response.getRaw() );
     }
 
     public JsonObject executeAndGetBody()

--- a/src/main/java/org/hisp/dhis/tasks/PostEventsTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/PostEventsTask.java
@@ -1,12 +1,8 @@
 package org.hisp.dhis.tasks;
 
 import com.google.gson.JsonObject;
-import io.restassured.http.ContentType;
-import io.restassured.response.Response;
-
-import static io.restassured.RestAssured.given;
-import static io.restassured.RestAssured.post;
-import static io.restassured.RestAssured.when;
+import org.hisp.dhis.actions.RestApiActions;
+import org.hisp.dhis.response.dto.ApiResponse;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -16,6 +12,8 @@ public class PostEventsTask
     DhisAbstractTask
 {
     private JsonObject body;
+
+    private String endpoint = "/api/events";
 
     public PostEventsTask( JsonObject body )
     {
@@ -29,21 +27,21 @@ public class PostEventsTask
 
     public String getName()
     {
-        return "Post events";
+        return "POST " + this.endpoint;
     }
 
     public void execute()
     {
-        Response response = given().contentType( ContentType.JSON ).body( body ).when().post( "/api/events" )
-            .thenReturn();
+        RestApiActions apiActions = new RestApiActions( this.endpoint );
+        ApiResponse response = apiActions.post( body );
 
         if ( response.statusCode() == 200 )
         {
-            recordSuccess( response );
+            recordSuccess( response.getRaw() );
             return;
         }
 
-        recordFailure( response );
+        recordFailure( response.getRaw() );
 
     }
 }

--- a/src/main/java/org/hisp/dhis/tasks/QueryEventsTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/QueryEventsTask.java
@@ -1,9 +1,8 @@
 package org.hisp.dhis.tasks;
 
 import com.google.gson.JsonObject;
-import io.restassured.response.Response;
-
-import static io.restassured.RestAssured.given;
+import org.hisp.dhis.actions.RestApiActions;
+import org.hisp.dhis.response.dto.ApiResponse;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -33,21 +32,21 @@ public class QueryEventsTask
 
     public void execute()
     {
-        Response response = given().get( query );
+        RestApiActions apiActions = new RestApiActions( this.query );
+        ApiResponse response = apiActions.get();
 
-        this.responseBody = response.body().as( JsonObject.class );
+        this.responseBody = response.getBody();
 
         if ( response.statusCode() == 200 )
         {
-            recordSuccess( response );
+            recordSuccess( response.getRaw() );
             return;
         }
 
-        recordFailure( response );
+        recordFailure( response.getRaw() );
     }
 
     public JsonObject executeAndGetBody()
-        throws Exception
     {
         execute();
         return responseBody;

--- a/src/main/java/org/hisp/dhis/tasks/QueryFilterTeiTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/QueryFilterTeiTask.java
@@ -28,9 +28,8 @@ package org.hisp.dhis.tasks;
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-import static io.restassured.RestAssured.when;
-
-import io.restassured.response.Response;
+import org.hisp.dhis.actions.RestApiActions;
+import org.hisp.dhis.response.dto.ApiResponse;
 
 /**
  * @author David Katuscak (katuscak.d@gmail.com)
@@ -39,12 +38,20 @@ public class QueryFilterTeiTask
     extends
     DhisAbstractTask
 {
-    private String endpoint = "/api/trackedEntityInstances/query.json";
+    private int weight;
+
+    private String endpoint = "/api/trackedEntityInstances/query";
+
     private String query = "?ou=DiszpKrYNg8&attribute=TfdH5KvFmMy&filter=TfdH5KvFmMy:GE:Karoline";
+
+    public QueryFilterTeiTask( int weight )
+    {
+        this.weight = weight;
+    }
 
     public int getWeight()
     {
-        return 1;
+        return this.weight;
     }
 
     @Override
@@ -54,16 +61,17 @@ public class QueryFilterTeiTask
     }
 
     @Override
-    public void execute() throws Exception
+    public void execute()
+        throws Exception
     {
-        Response response = when().get( endpoint + query );
+        ApiResponse response = new RestApiActions( endpoint ).get( query );
 
         if ( response.statusCode() == 200 )
         {
-            recordSuccess( response );
+            recordSuccess( response.getRaw() );
             return;
         }
 
-        recordFailure( response );
+        recordFailure( response.getRaw() );
     }
 }

--- a/src/main/java/org/hisp/dhis/utils/CacheUtils.java
+++ b/src/main/java/org/hisp/dhis/utils/CacheUtils.java
@@ -1,14 +1,13 @@
 package org.hisp.dhis.utils;
 
-import java.io.*;
-import java.util.ArrayList;
-
-import org.hisp.dhis.cache.*;
-
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.io.Input;
 import com.esotericsoftware.kryo.io.Output;
 import com.esotericsoftware.kryo.serializers.CollectionSerializer;
+import org.hisp.dhis.cache.*;
+
+import java.io.*;
+import java.util.ArrayList;
 
 public class CacheUtils
 {
@@ -59,7 +58,8 @@ public class CacheUtils
         return new File( CACHE_FILE ).exists();
     }
 
-    public static String getCachePath( ) {
+    public static String getCachePath()
+    {
 
         return CACHE_FILE;
     }

--- a/src/main/java/org/hisp/dhis/utils/RandomUtils.java
+++ b/src/main/java/org/hisp/dhis/utils/RandomUtils.java
@@ -1,20 +1,15 @@
 package org.hisp.dhis.utils;
 
-import static net.andreinc.mockneat.unit.time.LocalDates.localDates;
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Point;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.Point;
+import static net.andreinc.mockneat.unit.time.LocalDates.localDates;
 
 public class RandomUtils
 {
@@ -36,7 +31,7 @@ public class RandomUtils
     {
         LocalDateTime localDateTime = new Date().toInstant().atZone( ZoneId.systemDefault() ).toLocalDateTime();
         return localDates().future( localDateTime.plusYears( 1 ).toLocalDate() )
-                .display( DateTimeFormatter.ISO_LOCAL_DATE ).get() + " 00:00:00";
+            .display( DateTimeFormatter.ISO_LOCAL_DATE ).get() + " 00:00:00";
     }
 
 }

--- a/src/main/resources/locust.properties
+++ b/src/main/resources/locust.properties
@@ -1,8 +1,6 @@
-
 locust.master.port=5557
 locust.master.host=127.0.0.1
 #target.baseuri=https://play.dhis2.org/dev
-target.baseuri=http://localhost:8080/dhis
-
+target.baseuri=https://giocare.dhis2.org/perf_dev
 # API versions
 analytics.api.version=30


### PR DESCRIPTION
This PR makes use of the api-test-utils framework that is meant to be shared by the API tests and performance tests. Abstracts away rest-assured a bit by utilizing helper class ApiResponse instead of Response. Provides helper methods for posting, getting, updating entities and means to inspect the response.