### PR TITLE
fix: using request types instead of http for type

### DIFF
--- a/src/main/java/org/hisp/dhis/Main.java
+++ b/src/main/java/org/hisp/dhis/Main.java
@@ -1,34 +1,30 @@
 package org.hisp.dhis;
 
-import static io.restassured.config.RestAssuredConfig.config;
-import static org.aeonbits.owner.ConfigFactory.create;
-import static org.hisp.dhis.utils.CacheUtils.*;
-
-import java.io.IOException;
-
-import org.hisp.dhis.cache.EntitiesCache;
-import org.hisp.dhis.locust.LocustConfig;
-import org.hisp.dhis.locust.LocustSlave;
-import org.hisp.dhis.tasks.AddEventsTask;
-import org.hisp.dhis.tasks.CreateTrackedEntityAttributeTask;
-import org.hisp.dhis.tasks.GetAndUpdateEventsTask;
-import org.hisp.dhis.tasks.GetHeavyAnalyticsRandomTask;
-import org.hisp.dhis.tasks.GetHeavyAnalyticsTask;
-import org.hisp.dhis.tasks.LoginTask;
-
 import com.github.myzhan.locust4j.Locust;
 import com.google.gson.GsonBuilder;
-
 import io.restassured.RestAssured;
 import io.restassured.config.DecoderConfig;
 import io.restassured.config.EncoderConfig;
 import io.restassured.config.ObjectMapperConfig;
 import io.restassured.mapper.ObjectMapperType;
-import org.hisp.dhis.tasks.ReserveTrackedEntityAttributeValuesTask;
+import org.hisp.dhis.cache.EntitiesCache;
+import org.hisp.dhis.locust.LocustConfig;
+import org.hisp.dhis.locust.LocustSlave;
+import org.hisp.dhis.tasks.*;
+import org.hisp.dhis.tasks.analytics.GetHeavyAnalyticsRandomTask;
+import org.hisp.dhis.tasks.analytics.GetHeavyAnalyticsTask;
+import org.hisp.dhis.tasks.tracker.events.AddEventsTask;
+import org.hisp.dhis.tasks.tracker.events.GetAndUpdateEventsTask;
 import org.hisp.dhis.tasks.tracker.tei.AddTeiTask;
 import org.hisp.dhis.tasks.tracker.tei.FilterTeiTask;
 import org.hisp.dhis.tasks.tracker.tei.GetAndUpdateTeiTask;
 import org.hisp.dhis.tasks.tracker.tei.QueryFilterTeiTask;
+
+import java.io.IOException;
+
+import static io.restassured.config.RestAssuredConfig.config;
+import static org.aeonbits.owner.ConfigFactory.create;
+import static org.hisp.dhis.utils.CacheUtils.*;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -92,6 +88,8 @@ public class Main
                 new GetAndUpdateEventsTask( 2, "?orgUnit=DiszpKrYNg8" ),
                 new GetAndUpdateTeiTask( 2, cache ),
                 new AddEventsTask(3, cache)
+
         );
+        //locust.run( new AddEventsTask( 2, cache ) );
     }
 }

--- a/src/main/java/org/hisp/dhis/Main.java
+++ b/src/main/java/org/hisp/dhis/Main.java
@@ -90,6 +90,5 @@ public class Main
                 new AddEventsTask(3, cache)
 
         );
-        //locust.run( new AddEventsTask( 2, cache ) );
     }
 }

--- a/src/main/java/org/hisp/dhis/tasks/CreateTrackedEntityAttributeTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/CreateTrackedEntityAttributeTask.java
@@ -26,7 +26,13 @@ public class CreateTrackedEntityAttributeTask
 
     public String getName()
     {
-        return "POST " + endpoint;
+        return endpoint;
+    }
+
+    @Override
+    public String getType()
+    {
+        return "POST";
     }
 
     public void execute()

--- a/src/main/java/org/hisp/dhis/tasks/DhisAbstractTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/DhisAbstractTask.java
@@ -20,27 +20,29 @@ public abstract class DhisAbstractTask
 
     public abstract String getName();
 
+    public abstract String getType();
+
     public abstract void execute()
         throws Exception;
 
     public void recordSuccess( Response response )
     {
-        Locust.getInstance().recordSuccess( "http", getName(), response.getTime(),
+        Locust.getInstance().recordSuccess( getType(), getName(), response.getTime(),
             response.getBody().asByteArray().length );
     }
 
     public void recordSuccess( long time, long length )
     {
-        Locust.getInstance().recordSuccess( "http", getName(), time, length );
+        Locust.getInstance().recordSuccess( getType(), getName(), time, length );
     }
 
     public void recordFailure( long time, String message )
     {
-        Locust.getInstance().recordFailure( "http", getName(), time, message );
+        Locust.getInstance().recordFailure( getType(), getName(), time, message );
     }
 
     public void recordFailure( Response response )
     {
-        Locust.getInstance().recordFailure( "http", getName(), response.getTime(), response.getBody().print() );
+        Locust.getInstance().recordFailure( getType(), getName(), response.getTime(), response.getBody().print() );
     }
 }

--- a/src/main/java/org/hisp/dhis/tasks/LoginTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/LoginTask.java
@@ -23,6 +23,12 @@ public class LoginTask
         return "Authenticate";
     }
 
+    @Override
+    public String getType()
+    {
+        return "http";
+    }
+
     public void execute()
     {
         RestAssured.getRestAssured().authentication = preemptive().basic( "system", "System123" );

--- a/src/main/java/org/hisp/dhis/tasks/MetadataExportImportTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/MetadataExportImportTask.java
@@ -28,6 +28,12 @@ public class MetadataExportImportTask
         return "Metadata export/import";
     }
 
+    @Override
+    public String getType()
+    {
+        return "https";
+    }
+
     public void execute()
         throws Exception
     {

--- a/src/main/java/org/hisp/dhis/tasks/MetadataExportTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/MetadataExportTask.java
@@ -24,6 +24,12 @@ public class MetadataExportTask
         return "Export all metadata";
     }
 
+    @Override
+    public String getType()
+    {
+        return "GET";
+    }
+
     public void execute()
         throws Exception
     {

--- a/src/main/java/org/hisp/dhis/tasks/ReserveTrackedEntityAttributeValuesTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/ReserveTrackedEntityAttributeValuesTask.java
@@ -23,7 +23,13 @@ public class ReserveTrackedEntityAttributeValuesTask
 
     public String getName()
     {
-        return "POST /api/trackedEntityAttributes/{id}/generateAndReserve";
+        return "/api/trackedEntityAttributes/{id}/generateAndReserve";
+    }
+
+    @Override
+    public String getType()
+    {
+        return "POST";
     }
 
     public void execute()

--- a/src/main/java/org/hisp/dhis/tasks/analytics/GetHeavyAnalyticsRandomTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/analytics/GetHeavyAnalyticsRandomTask.java
@@ -1,10 +1,11 @@
-package org.hisp.dhis.tasks;
+package org.hisp.dhis.tasks.analytics;
 
 import org.hisp.dhis.actions.RestApiActions;
 import org.hisp.dhis.cache.EntitiesCache;
 import org.hisp.dhis.cache.Program;
 import org.hisp.dhis.request.QueryParamsBuilder;
 import org.hisp.dhis.response.dto.ApiResponse;
+import org.hisp.dhis.tasks.DhisAbstractTask;
 import org.hisp.dhis.utils.DataRandomizer;
 
 import java.util.List;
@@ -55,6 +56,12 @@ public class GetHeavyAnalyticsRandomTask
     public String getName()
     {
         return "(random) GET " + query();
+    }
+
+    @Override
+    public String getType()
+    {
+        return "GET";
     }
 
     public void execute()

--- a/src/main/java/org/hisp/dhis/tasks/analytics/GetHeavyAnalyticsTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/analytics/GetHeavyAnalyticsTask.java
@@ -1,9 +1,9 @@
-package org.hisp.dhis.tasks;
+package org.hisp.dhis.tasks.analytics;
 
-import io.restassured.specification.RequestSpecification;
 import org.hisp.dhis.actions.RestApiActions;
 import org.hisp.dhis.request.QueryParamsBuilder;
 import org.hisp.dhis.response.dto.ApiResponse;
+import org.hisp.dhis.tasks.DhisAbstractTask;
 
 import java.util.List;
 
@@ -52,6 +52,12 @@ public class GetHeavyAnalyticsTask
     public String getName()
     {
         return "(static) GET " + query();
+    }
+
+    @Override
+    public String getType()
+    {
+        return "GET";
     }
 
     public void execute()

--- a/src/main/java/org/hisp/dhis/tasks/tracker/events/AddEventsTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/tracker/events/AddEventsTask.java
@@ -1,4 +1,4 @@
-package org.hisp.dhis.tasks;
+package org.hisp.dhis.tasks.tracker.events;
 
 import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_OK;
 
@@ -17,6 +17,7 @@ import org.hisp.dhis.dxf2.events.event.Event;
 import org.hisp.dhis.random.EventRandomizer;
 import org.hisp.dhis.random.RandomizerContext;
 import org.hisp.dhis.response.dto.ApiResponse;
+import org.hisp.dhis.tasks.DhisAbstractTask;
 import org.hisp.dhis.utils.DataRandomizer;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -46,7 +47,13 @@ public class AddEventsTask
     @Override
     public String getName()
     {
-        return "POST /api/events";
+        return endpoint;
+    }
+
+    @Override
+    public String getType()
+    {
+        return "POST";
     }
 
     private Event createRandomEvent()

--- a/src/main/java/org/hisp/dhis/tasks/tracker/events/GetAndUpdateEventsTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/tracker/events/GetAndUpdateEventsTask.java
@@ -1,6 +1,8 @@
-package org.hisp.dhis.tasks;
+package org.hisp.dhis.tasks.tracker.events;
 
 import com.google.gson.JsonObject;
+import org.hisp.dhis.tasks.DhisAbstractTask;
+import org.hisp.dhis.tasks.LoginTask;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -20,6 +22,12 @@ public class GetAndUpdateEventsTask
     public String getName()
     {
         return "Get and update events task";
+    }
+
+    @Override
+    public String getType()
+    {
+        return "http";
     }
 
     public void execute()

--- a/src/main/java/org/hisp/dhis/tasks/tracker/events/PostEventsTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/tracker/events/PostEventsTask.java
@@ -1,8 +1,9 @@
-package org.hisp.dhis.tasks;
+package org.hisp.dhis.tasks.tracker.events;
 
 import com.google.gson.JsonObject;
 import org.hisp.dhis.actions.RestApiActions;
 import org.hisp.dhis.response.dto.ApiResponse;
+import org.hisp.dhis.tasks.DhisAbstractTask;
 
 import static com.google.api.client.http.HttpStatusCodes.STATUS_CODE_OK;
 
@@ -29,7 +30,13 @@ public class PostEventsTask
 
     public String getName()
     {
-        return "POST " + this.endpoint;
+        return this.endpoint;
+    }
+
+    @Override
+    public String getType()
+    {
+        return "POST";
     }
 
     public void execute()

--- a/src/main/java/org/hisp/dhis/tasks/tracker/events/QueryEventsTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/tracker/events/QueryEventsTask.java
@@ -1,8 +1,9 @@
-package org.hisp.dhis.tasks;
+package org.hisp.dhis.tasks.tracker.events;
 
 import com.google.gson.JsonObject;
 import org.hisp.dhis.actions.RestApiActions;
 import org.hisp.dhis.response.dto.ApiResponse;
+import org.hisp.dhis.tasks.DhisAbstractTask;
 
 /**
  * @author Gintare Vilkelyte <vilkelyte.gintare@gmail.com>
@@ -29,7 +30,13 @@ public class QueryEventsTask
 
     public String getName()
     {
-        return "GET events " + this.query;
+        return "/events" + this.query;
+    }
+
+    @Override
+    public String getType()
+    {
+        return "GET";
     }
 
     public void execute()

--- a/src/main/java/org/hisp/dhis/tasks/tracker/tei/AddTeiTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/tracker/tei/AddTeiTask.java
@@ -25,7 +25,13 @@ public class AddTeiTask
 
     public String getName()
     {
-        return "POST " + this.endpoint;
+        return this.endpoint;
+    }
+
+    @Override
+    public String getType()
+    {
+        return "POST";
     }
 
     public void execute()

--- a/src/main/java/org/hisp/dhis/tasks/tracker/tei/FilterTeiTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/tracker/tei/FilterTeiTask.java
@@ -50,7 +50,13 @@ public class FilterTeiTask
     @Override
     public String getName()
     {
-        return "Get TEI's matching filter " + endpoint + query;
+        return "TEI's matching filter " + endpoint + query;
+    }
+
+    @Override
+    public String getType()
+    {
+        return "GET";
     }
 
     @Override

--- a/src/main/java/org/hisp/dhis/tasks/tracker/tei/GetAndUpdateTeiTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/tracker/tei/GetAndUpdateTeiTask.java
@@ -50,7 +50,13 @@ public class GetAndUpdateTeiTask
     @Override
     public String getName()
     {
-        return "PUT /trackedEntityInstances/$id";
+        return "/trackedEntityInstances/$id";
+    }
+
+    @Override
+    public String getType()
+    {
+        return "PUT";
     }
 
     @Override

--- a/src/main/java/org/hisp/dhis/tasks/tracker/tei/GetTeiTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/tracker/tei/GetTeiTask.java
@@ -22,7 +22,13 @@ public class GetTeiTask
     @Override
     public String getName()
     {
-        return "GET /trackedEntityInstances/$id";
+        return "/trackedEntityInstances/$id";
+    }
+
+    @Override
+    public String getType()
+    {
+        return "GET";
     }
 
     @Override

--- a/src/main/java/org/hisp/dhis/tasks/tracker/tei/GetTeisTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/tracker/tei/GetTeisTask.java
@@ -27,7 +27,13 @@ public class GetTeisTask
     @Override
     public String getName()
     {
-        return "GET /trackedEntityInstances";
+        return "/trackedEntityInstances";
+    }
+
+    @Override
+    public String getType()
+    {
+        return "GET";
     }
 
     @Override

--- a/src/main/java/org/hisp/dhis/tasks/tracker/tei/QueryFilterTeiTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/tracker/tei/QueryFilterTeiTask.java
@@ -58,7 +58,13 @@ public class QueryFilterTeiTask
     @Override
     public String getName()
     {
-        return "Get TEI's query matching filter " + endpoint + query;
+        return "TEI's query matching filter " + endpoint + query;
+    }
+
+    @Override
+    public String getType()
+    {
+        return "GET";
     }
 
     @Override

--- a/src/main/resources/locust.properties
+++ b/src/main/resources/locust.properties
@@ -1,7 +1,6 @@
 locust.master.port=5557
 locust.master.host=127.0.0.1
 #target.baseuri=https://play.dhis2.org/dev
-target.baseuri=http://localhost:8080/dhis
-
+target.baseuri=https://test.performance.dhis2.org/post-event
 # API versions
 analytics.api.version=30


### PR DESCRIPTION
- Using the request type as a type instead of HTTP. I think it increases visibility a bit. HTTP wasn't really useful. 
![image](https://user-images.githubusercontent.com/12664326/84754500-c57b5f80-afc0-11ea-88f6-f64407caa9b3.png)
- Organizing tests into packages 
