### PR TITLE
Update id-generation tests

### DIFF
--- a/src/main/java/org/hisp/dhis/cache/GeneratedTrackedEntityAttribute.java
+++ b/src/main/java/org/hisp/dhis/cache/GeneratedTrackedEntityAttribute.java
@@ -17,7 +17,7 @@ public class GeneratedTrackedEntityAttribute
 
     private String name = "test generated value";
 
-    private String pattern = "RANDOM(####)";
+    private String pattern = "SEQUENTIAL(####)";
 
     private String shortName = "test_generated_value3";
 

--- a/src/main/java/org/hisp/dhis/tasks/LoginTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/LoginTask.java
@@ -31,7 +31,7 @@ public class LoginTask
 
     public void execute()
     {
-        RestAssured.getRestAssured().authentication = preemptive().basic( "system", "System123" );
+        RestAssured.getRestAssured().authentication = preemptive().basic( "admin", "district" );
 
         Response apiResponse = RestAssured.getRestAssured().given().contentType( ContentType.TEXT ).when()
             .get( "api/me" ).thenReturn();

--- a/src/main/java/org/hisp/dhis/tasks/ReserveTrackedEntityAttributeValuesTask.java
+++ b/src/main/java/org/hisp/dhis/tasks/ReserveTrackedEntityAttributeValuesTask.java
@@ -1,14 +1,9 @@
 package org.hisp.dhis.tasks;
 
-import com.github.myzhan.locust4j.Locust;
 import io.restassured.response.Response;
 import org.hisp.dhis.actions.RestApiActions;
 import org.hisp.dhis.request.QueryParamsBuilder;
 import org.hisp.dhis.response.dto.ApiResponse;
-
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 public class ReserveTrackedEntityAttributeValuesTask
     extends
@@ -35,34 +30,13 @@ public class ReserveTrackedEntityAttributeValuesTask
     public void execute()
     {
         RestApiActions trackedEntityAttributeActions = new RestApiActions( endpoint );
-        long time = System.currentTimeMillis();
 
-        List<ApiResponse> setupResponses = null;
+        String attributeID = "c5Mvtl3GuIb";
 
-        ApiResponse response = null;
+        ApiResponse response = trackedEntityAttributeActions.get( attributeID + "/generateAndReserve",
+                new QueryParamsBuilder().add( "numberToReserve", "1" ) );
 
-        String attributeId = new CreateTrackedEntityAttributeTask().executeAndGetId();
-
-        setupResponses = IntStream.range( 0, 10 ).mapToObj( r ->
-            trackedEntityAttributeActions.get( attributeId + "/generateAndReserve",
-                new QueryParamsBuilder().add( "numberToReserve", "800" ) ) )
-            .collect( Collectors.toList() );
-
-        response = trackedEntityAttributeActions.get( attributeId + "/generateAndReserve",
-            new QueryParamsBuilder().add( "numberToReserve", "800" ) );
-
-        if ( setupResponses.stream().allMatch( r -> r.statusCode() == 200 ) )
-        {
-            record( response.getRaw() );
-        }
-
-        else
-        {
-            ApiResponse failureResponse = setupResponses.stream().filter( r -> r.statusCode() != 200 ).findFirst().get();
-
-            Locust.getInstance().recordFailure( "http", getName() + " SETUP",
-                System.currentTimeMillis() - time, failureResponse.getRaw().getBody().print() );
-        }
+        record( response.getRaw() );
     }
 
     private void record( Response response )


### PR DESCRIPTION
Update pattern from RANDOM to SEQUENTIAL (More determenistic behaviour; RANDOM should be avoided in general)
Update test to only reserve a single value for each concurrent user. Previously would try to reserve ~8000 values for each concurrent user. official DHIS2 apps reserve either 100(android) or 1(web) normally.
Update logintask. system does not work on empty database.