### PR TITLE
ci: relax docker compose restart policy on locust

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   locust:
-    restart: always
+    restart: unless-stopped
     image: "dhis2/locustio:latest"
     environment:
       LOCUST_MASTER_NODE_HOST: "127.0.0.1"


### PR DESCRIPTION
as in https://github.com/dhis2/dhis2-core/pull/11605

whenever I restart my machine the performance-tests-locust-locust-1
keeps on being started by Docker due to the
https://docs.docker.com/config/containers/start-containers-automatically/
This is annoying as it blocks a port and is wasting resources if I do
not want to run locust tests.

unless-stopped is 'Similar to always, except that when the container is stopped (manually or otherwise), it is not restarted even after Docker daemon restarts.'